### PR TITLE
Separate remove switch to function

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,19 @@ Hashes for KRBTGT:
   AES128: j916...
   AES256: k093...
 ```
+
+## Remove-ServerUntrustAccount
+This function is a clean up function to remove persistence items created from Add-ServerUntrustAccount. It performs the following activities:
+ * Remove ACE for the backdoor security principal on Domain with DS-Install-Replica permission
+ * Remove ACE on the computer / managed service account object to modify UserAccountcontrol attribute
+ * When deleteComputer parameter is specified, also delete the computer / managed service account object
+
+```
+PS > . .\ServerUntrustAccount.ps1
+PS > Remove-ServerUntrustAccount -ComputerName FakeComputer123 -DeleteComputer
+
+Confirm
+Are you sure you want to perform this action?
+Performing the operation "Remove" on target "CN=FakeComputer123,CN=Computers,DC=domain,DC=local".
+[Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "Y"):
+PS >

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ Hashes for KRBTGT:
 ```
 
 ## Remove-ServerUntrustAccount
-This function is a clean up function to remove persistence items created from Add-ServerUntrustAccount. It performs the following activities:
- * Remove ACE for the backdoor security principal on Domain with DS-Install-Replica permission
- * Remove ACE on the computer / managed service account object to modify UserAccountcontrol attribute
- * When deleteComputer parameter is specified, also delete the computer / managed service account object
+This function removes accounts and permissions created using `Add-ServerUntrustAccount`. It performs the following actions:
+ * Remove the DS-Install-Replica permission on the domain object for the specified computer or managed service account
+ * Remove the modify userAccountControl permission on the specified computer or managed service account object
+ * With the deleteComputer switch enabled, also deletes the specified computer or managed service account object
 
 ```
 PS > . .\ServerUntrustAccount.ps1

--- a/ServerUntrustAccount.ps1
+++ b/ServerUntrustAccount.ps1
@@ -366,16 +366,16 @@ function Remove-ServerUntrustAccount
 	param
 	(
 		[Parameter(Mandatory = $false)]
-		[ValidateNotNullOrEmpty()]
-		[System.String]$DomainFQDN = $ENV:USERDNSDOMAIN,
-		[Parameter(Mandatory = $false)]
 		[ValidateNotNull()]
 		[ValidateNotNullOrEmpty()]
 		[System.String]$ComputerName = 'FakeComputer1',
+		[switch]$DeleteComputer,
 		[ValidateNotNull()]
 		[ValidateNotNullOrEmpty()]
 		[System.String]$DomainDN = ([adsi]"" | Select-Object -ExpandProperty distinguishedname),
-		[switch]$DeleteComputer
+		[Parameter(Mandatory = $false)]
+		[ValidateNotNullOrEmpty()]
+		[System.String]$DomainFQDN = $ENV:USERDNSDOMAIN		
 	)
 	
 	#####################################

--- a/ServerUntrustAccount.ps1
+++ b/ServerUntrustAccount.ps1
@@ -57,9 +57,6 @@ SOFTWARE.
 	
 	.PARAMETER DomainDN
 		The DistinguishedName of the domain.
-	
-	.PARAMETER Remove
-		A switch to remove previously created ACLs from the domain and computer objects
 
 	.PARAMETER MSA
 		A switch to create a standalone Managed Service Account instead of a computer.
@@ -74,10 +71,6 @@ SOFTWARE.
 
 		PS C:\> Add-ServerUntrustAccount -ComputerName "SVC_SQL" -MSA
 
-	.EXAMPLE
-		Removes the "Authenticated Users" ACLs from the domain and "UK-Laptop1" computer objects
-
-		PS C:\> Add-ServerUntrustAccount -ComputerName "UK-Laptop1" -Remove
 #>
 function Add-ServerUntrustAccount
 {

--- a/ServerUntrustAccount.ps1
+++ b/ServerUntrustAccount.ps1
@@ -101,7 +101,7 @@ function Add-ServerUntrustAccount
 WARNING: This script is a demonstration of an attack technique and it will grant the Authenticated Users security
 principal the DS-Install-Replica privilege in your domain. This privilege exposes the domain to a number of attack
 vectors. Before running this script you should understand the full potential impact of this privilege. 
-Be sure to remove this privilege (see the -Remove switch) when testing is complete.
+Be sure to remove this privilege (see the Remove-ServerUntrustAccount function) when testing is complete.
 To continue, type CONFIRM
 "@
 	
@@ -504,6 +504,7 @@ function Remove-ServerUntrustAccount
 			Write-Error -Message "Did not find any objects with the name $ComputerName"
 		} else
 		{
+			Write-Verbose -Message "Removing the object $($Lookup_Computer.DistinguishedName)."
 			$Lookup_Computer | Remove-ADObject
 		}
 	}

--- a/ServerUntrustAccount.ps1
+++ b/ServerUntrustAccount.ps1
@@ -365,10 +365,7 @@ function Remove-ServerUntrustAccount
 		[switch]$DeleteComputer,
 		[ValidateNotNull()]
 		[ValidateNotNullOrEmpty()]
-		[System.String]$DomainDN = ([adsi]"" | Select-Object -ExpandProperty distinguishedname),
-		[Parameter(Mandatory = $false)]
-		[ValidateNotNullOrEmpty()]
-		[System.String]$DomainFQDN = $ENV:USERDNSDOMAIN		
+		[System.String]$DomainDN = ([adsi]"" | Select-Object -ExpandProperty distinguishedname)
 	)
 	
 	#####################################

--- a/ServerUntrustAccount.ps1
+++ b/ServerUntrustAccount.ps1
@@ -351,7 +351,45 @@ function Invoke-ServerUntrustAccount
 
 
 
+<#
+	.SYNOPSIS
+		A function to remove the persistence configurations created by Add-ServerUntrustAccount.
+	
+	.DESCRIPTION
+		This function can remove the following persistence configurations created by Add-ServerUntrustAccount:
+			- Remove Security Principal with Ds-Install-Replica from the Domain Object
+			- Remove the UserAccountControl Modification ACL from MSA/GMSA/Computer Object
+			- Remove the Computer/MSA/GMSA, only when -DeleteComputer switch is specified.
 
+	.PARAMETER ComputerName
+		Specifies the MSA/Computer name of which to either delete or remove the UserAccountControl ACLs from.
+
+		Default Value: FakeComputer1
+		Type: String
+
+	.PARAMETER DeleteComputer
+		When specified the Computer Object will be deleted from Active Directory as clean up.
+
+		Default Value: $False (not specified)
+		Type: Switch 
+
+	.PARAMETER DomainDN
+		The Domain DistinguishedName of the domain in which it is intended to remove the Security Principal From the Ds-Install-Replica ACE
+
+		Default Value: ([adsi]"" | Select-Object -ExpandProperty distinguishedname) -> Current Domain DistinguishedName
+		Type: String
+
+	.EXAMPLE
+		Remove only ACE's but not the computer object
+
+		Remove-ServerUntrustAccount -ComputerName "Computer1"
+
+	.EXAMPLE
+		Remove the ACE's and delete the computer object
+
+		Remove-ServerUntrustAccount -ComputerName "Computer1" -DeleteComputer
+	
+#>
 function Remove-ServerUntrustAccount
 {
 	#Requires -Module ActiveDirectory


### PR DESCRIPTION
PR for #4 

All -Remove functionality and more has been moved from Add-ServerUntrustAccount to Remove-ServerUntrustAccount.

Added ability to also delete the computer or managed service account object as part of the clean up also.

Added some extra checks for things like duplicate accounts just in case multiple accounts with same name are discovered for ACE or Object removals.